### PR TITLE
example(agentic-frameworks-missing-hub): server — article companion README; java afterValueUpdated, python on_

### DIFF
--- a/examples/java/agentic-frameworks-missing-hub/README.md
+++ b/examples/java/agentic-frameworks-missing-hub/README.md
@@ -50,3 +50,11 @@ cp kiponos.local.env.example kiponos.local.env
 ```
 
 Repo: [github.com/kiponos-io/kiponos-io](https://github.com/kiponos-io/kiponos-io)
+
+## Published (medium)
+
+Agent Frameworks Gave Us Tools. They Did Not Give Us a Live Hub.
+
+https://medium.com/@devops_16625/agent-frameworks-gave-us-tools-they-did-not-give-us-a-live-hub-e1440e0a11b4
+
+Same Team leaf as this example — no cross-post of the essay body.

--- a/examples/java/agentic-frameworks-missing-hub/src/main/java/io/kiponos/examples/agentic/AgenticFrameworksMissingHubApp.java
+++ b/examples/java/agentic-frameworks-missing-hub/src/main/java/io/kiponos/examples/agentic/AgenticFrameworksMissingHubApp.java
@@ -1,6 +1,7 @@
 package io.kiponos.examples.agentic;
 
 import io.kiponos.sdk.Kiponos;
+import io.kiponos.sdk.data.ConfigValUpdatedResponse;
 import io.kiponos.sdk.configs.Folder;
 
 /**
@@ -23,6 +24,10 @@ public final class AgenticFrameworksMissingHubApp {
         Kiponos k = Kiponos.createForCurrentTeam();
         try {
             Folder p = ensure(k);
+            k.afterValueUpdated((ConfigValUpdatedResponse ev) -> {
+                if (ev == null || ev.getKey() == null) { return; }
+                // live leaf examples/agentic-frameworks-missing-hub — next decide() is in-memory, no MCP restart
+            });
             String v = args.length > 0 ? args[0] : read(p, KEY, DEFAULT);
             Decision d = decide(v);
             System.out.println("examples/" + FOLDER + "/" + KEY + "=" + d.value());

--- a/examples/node/agentic-frameworks-missing-hub-angular/README.md
+++ b/examples/node/agentic-frameworks-missing-hub-angular/README.md
@@ -53,3 +53,11 @@ node peer.mjs --serve   # BFF; SPA fetches /posture
 ```
 
 Repo: [github.com/kiponos-io/kiponos-io](https://github.com/kiponos-io/kiponos-io)
+
+## Published (medium)
+
+Agent Frameworks Gave Us Tools. They Did Not Give Us a Live Hub.
+
+https://medium.com/@devops_16625/agent-frameworks-gave-us-tools-they-did-not-give-us-a-live-hub-e1440e0a11b4
+
+Same Team leaf as this example — no cross-post of the essay body.

--- a/examples/node/agentic-frameworks-missing-hub-react/README.md
+++ b/examples/node/agentic-frameworks-missing-hub-react/README.md
@@ -53,3 +53,11 @@ node peer.mjs --serve   # BFF; SPA fetches /posture
 ```
 
 Repo: [github.com/kiponos-io/kiponos-io](https://github.com/kiponos-io/kiponos-io)
+
+## Published (medium)
+
+Agent Frameworks Gave Us Tools. They Did Not Give Us a Live Hub.
+
+https://medium.com/@devops_16625/agent-frameworks-gave-us-tools-they-did-not-give-us-a-live-hub-e1440e0a11b4
+
+Same Team leaf as this example — no cross-post of the essay body.

--- a/examples/python/agentic-frameworks-missing-hub/README.md
+++ b/examples/python/agentic-frameworks-missing-hub/README.md
@@ -51,3 +51,11 @@ KIPONOS_LIVE=1 python3 peer.py   # optional live hub
 ```
 
 Repo: [github.com/kiponos-io/kiponos-io](https://github.com/kiponos-io/kiponos-io)
+
+## Published (medium)
+
+Agent Frameworks Gave Us Tools. They Did Not Give Us a Live Hub.
+
+https://medium.com/@devops_16625/agent-frameworks-gave-us-tools-they-did-not-give-us-a-live-hub-e1440e0a11b4
+
+Same Team leaf as this example — no cross-post of the essay body.

--- a/examples/python/agentic-frameworks-missing-hub/peer.py
+++ b/examples/python/agentic-frameworks-missing-hub/peer.py
@@ -43,6 +43,13 @@ def _live(d: dict) -> None:
     k = Kiponos.connect(quiet=True)
     try:
         k.ensure_path("examples/agentic-frameworks-missing-hub")
+
+        def _on_change(key, value, folders=(), source="", delta=None):
+            # dashboard edit → in-memory tree; MCP host does not restart
+            print("on_change", "/".join(folders + (key,)), "=", value)
+
+        if hasattr(k, "on_change"):
+            k.on_change(_on_change)
         live = k.get(PATH, DEFAULT)
         got = decide(str(live) if live is not None else DEFAULT)
         print("live", PATH, "=", got["value"], "action=", got["action"])


### PR DESCRIPTION
Role **Kiponos Server** (`server-sdk@kiponos.io`).

article companion README; java afterValueUpdated, python on_change.

PRs are merged by the kiponos-io org account. Distinct GitHub *usernames* need separate org members (optional PATs in authors.json env keys).
