### PR TITLE
example(agentic-med-1009-mi-budget-turn): server — java afterValueUpdated, python on_change

### DIFF
--- a/examples/java/agentic-med-1009-mi-budget-turn/src/main/java/io/kiponos/examples/agentic/AgenticMed1009MiBudgetTurnApp.java
+++ b/examples/java/agentic-med-1009-mi-budget-turn/src/main/java/io/kiponos/examples/agentic/AgenticMed1009MiBudgetTurnApp.java
@@ -1,6 +1,7 @@
 package io.kiponos.examples.agentic;
 
 import io.kiponos.sdk.Kiponos;
+import io.kiponos.sdk.data.ConfigValUpdatedResponse;
 import io.kiponos.sdk.configs.Folder;
 
 /**
@@ -23,6 +24,10 @@ public final class AgenticMed1009MiBudgetTurnApp {
         Kiponos k = Kiponos.createForCurrentTeam();
         try {
             Folder p = ensure(k);
+            k.afterValueUpdated((ConfigValUpdatedResponse ev) -> {
+                if (ev == null || ev.getKey() == null) { return; }
+                // live leaf examples/agentic-med-1009-mi-budget-turn — next decide() is in-memory, no MCP restart
+            });
             String v = args.length > 0 ? args[0] : read(p, KEY, DEFAULT);
             Decision d = decide(v);
             System.out.println("examples/" + FOLDER + "/" + KEY + "=" + d.value());

--- a/examples/python/agentic-med-1009-mi-budget-turn/peer.py
+++ b/examples/python/agentic-med-1009-mi-budget-turn/peer.py
@@ -47,6 +47,13 @@ def _live(d: dict) -> None:
     k = Kiponos.connect(quiet=True)
     try:
         k.ensure_path("examples/agentic-med-1009-mi-budget-turn")
+
+        def _on_change(key, value, folders=(), source="", delta=None):
+            # dashboard edit → in-memory tree; MCP host does not restart
+            print("on_change", "/".join(folders + (key,)), "=", value)
+
+        if hasattr(k, "on_change"):
+            k.on_change(_on_change)
         live = k.get(PATH, DEFAULT)
         got = decide(str(live) if live is not None else DEFAULT)
         print("live", PATH, "=", got["value"], "action=", got["action"])


### PR DESCRIPTION
Role **Kiponos Server** (`server-sdk@kiponos.io`).

java afterValueUpdated, python on_change.

PRs are merged by the kiponos-io org account. Distinct GitHub *usernames* need separate org members (optional PATs in authors.json env keys).
